### PR TITLE
Clean camera API folder before regenerating API

### DIFF
--- a/camera/rpi-files/generate-api-client.sh
+++ b/camera/rpi-files/generate-api-client.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+rm -rf ./api-client/
+
 java -jar openapi-generator-cli.jar generate \
    -i ../../specs/api.yaml \
    -g python \


### PR DESCRIPTION
API generation works, but client folder should be cleaned up before generation. Closes #49.