### PR TITLE
Camera: upload events through API endpoint

### DIFF
--- a/.github/workflows/camera_cq.yaml
+++ b/.github/workflows/camera_cq.yaml
@@ -19,13 +19,11 @@ jobs:
         cd "camera/rpi-files/" &&
         ./setup-environment.sh &&
         cd -
-    - name: Lint with wemake-python-styleguide
-      uses: wemake-services/wemake-python-styleguide@0.13.4
-      with:
-        path: 'camera/rpi-files/'
-        reporter: 'github-pr-review'
-      env:
-        GITHUB_TOKEN: ${{ secrets.github_token }}
+    - name: Lint with flake8/wemake
+      run: |
+        cd "camera/rpi-files/" &&
+        pipenv run flake8 --config=setup.cfg &&
+        cd -
     - name: Test with pytest
       run: |
         cd "camera/rpi-files/" &&

--- a/camera/rpi-files/api_connector.py
+++ b/camera/rpi-files/api_connector.py
@@ -13,10 +13,15 @@ from openapi_client import ApiClient, CameraEvent, CamerasApi, Configuration
 from openapi_client.rest import ApiException
 
 
-class Uploader(object):
+class ApiConnector(object):
     """Uploads events to API endpoint."""
 
-    def __init__(self, device_id: int, configuration: Configuration, timestamp:datetime):
+    def __init__(
+        self,
+        device_id: int,
+        configuration: Configuration,
+        timestamp: datetime,
+    ):
         """Save path for writing.
 
         Args:
@@ -45,7 +50,7 @@ class Uploader(object):
             batch.entering, EventType.person_entered,
         ) and self._send_all_as(batch.leaving, EventType.person_left)
 
-    def end(self, timestamp):
+    def close(self, timestamp):
         """Notify endpoint that upload ends.
 
         Args:
@@ -65,7 +70,7 @@ class Uploader(object):
             RuntimeError: on upload failure
 
         Returns:
-            HTTP response object
+            true when upload finalizes
         """
         camera_pk = str(self._device_id)
         try:

--- a/camera/rpi-files/data_archiver.py
+++ b/camera/rpi-files/data_archiver.py
@@ -8,18 +8,9 @@ DataArchiver saves batches in a selected format.
 import csv
 import os
 from abc import ABC
-from enum import Enum
 
 from data_batcher import Batch
-
-
-class EventType(Enum):
-    """Enum for event types."""
-
-    monitoring_started = 0
-    monitoring_ended = 1
-    person_entered = 2
-    person_left = 3
+from events import EventType
 
 
 class DataArchiver(ABC):
@@ -28,7 +19,7 @@ class DataArchiver(ABC):
     def init(self):
         """Initialize the archive if not initialized."""
 
-    def append_event(self, timestamp: float, event_type: Enum):
+    def append_event(self, timestamp: float, event_type: EventType):
         """Includes single event in the archive. May not flush archive yet.
 
         Args:
@@ -151,8 +142,8 @@ class CsvArchiver(DataArchiver):
         self._writer.writeheader()
 
         # Write data timestamp by timestamp
-        for timestamp in self._entries.items():
-            self._writer.writerow(self._entries[timestamp])
+        for _, entry in self._entries.items():
+            self._writer.writerow(entry)
 
     def finalize(self):
         """Finalize the archive. No more data can be saved."""

--- a/camera/rpi-files/events.py
+++ b/camera/rpi-files/events.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""Event type definitions."""
+
+from datetime import datetime
+from enum import Enum
+
+from openapi_client import CameraEvent
+
+
+class EventType(Enum):
+    """Enum for event types."""
+
+    monitoring_started = 0
+    monitoring_ended = 1
+    person_entered = 2
+    person_left = 3
+
+
+def create_event(event_type: EventType, timestamp: datetime) -> CameraEvent:
+    """Create camera event instance.
+
+    Args:
+        event_type: event type
+        timestamp: event timestamp
+
+    Returns:
+        new camera event
+    """
+    return CameraEvent(event_type=event_type.value, timestamp=timestamp)

--- a/camera/rpi-files/format-lint-test.sh
+++ b/camera/rpi-files/format-lint-test.sh
@@ -8,11 +8,13 @@ function join {
 }
 
 SOURCES=(
-    "main.py" \
     "data_archiver.py" \
     "data_batcher.py" \
+    "events.py" \
     "frame_ingestor.py" \
-    "people_counter.py"
+    "main.py" \
+    "people_counter.py" \
+    "uploader.py"
 )
 
 TESTS=(

--- a/camera/rpi-files/format-lint-test.sh
+++ b/camera/rpi-files/format-lint-test.sh
@@ -8,13 +8,13 @@ function join {
 }
 
 SOURCES=(
+    "api_connector.py" \
     "data_archiver.py" \
     "data_batcher.py" \
     "events.py" \
     "frame_ingestor.py" \
     "main.py" \
-    "people_counter.py" \
-    "uploader.py"
+    "people_counter.py"
 )
 
 TESTS=(

--- a/camera/rpi-files/main.py
+++ b/camera/rpi-files/main.py
@@ -144,11 +144,6 @@ class Main(object):
                 cv2.imshow('Frame', frame)
                 cv2.waitKey(1)
 
-            # Count iterations for demo purposes
-            iteration += 1
-            if iteration == 6:
-                self._should_close = True
-
         self._close()
 
     def _start_monitoring(self):

--- a/camera/rpi-files/sample.env
+++ b/camera/rpi-files/sample.env
@@ -1,6 +1,6 @@
 # API connection
-API_HOST=https://eaterslab.example/beta
-DEVICE_ID=test-cam-1
+API_HOST=https://eaterslab.herokuapp.com/api/beta
+DEVICE_ID=1
 API_KEY=XXXXXX
 
 # Archives

--- a/camera/rpi-files/setup-environment.sh
+++ b/camera/rpi-files/setup-environment.sh
@@ -13,7 +13,6 @@ if [ "$PWD" != "${SCRIPT_PATH}" ]; then
 fi
 
 # Install Python, OpenJDK and wget
-sudo apt-get update &&
 sudo apt-get install python3.7 python3-pip python3-setuptools openjdk-11-jre-headless wget &&
 sudo pip3 install pipenv &&
 
@@ -28,4 +27,4 @@ java -jar openapi-generator-cli.jar generate -i "${API_PATH}" -g python -o "${AP
 pipenv install
 
 # Set up paths
-mkdir archives
+mkdir -p archives

--- a/camera/rpi-files/setup.cfg
+++ b/camera/rpi-files/setup.cfg
@@ -22,7 +22,7 @@ per-file-ignores =
     # WPS201: Ignore many methods in the main file
     # WPS213: Ignore many expressions in the main file
     # WPS214: Ignore many methods in the main file
-    main.py: WPS201, WPS213, WPS214,
+    main.py: WPS201, WPS213, WPS214
     # S101: Ignore banned assert in testing
     # WPS202: Ignore many members in test suites
     # WPS204: Ignore repeated calls in test suites

--- a/camera/rpi-files/setup.cfg
+++ b/camera/rpi-files/setup.cfg
@@ -19,6 +19,10 @@ exclude =
     camera/rpi-files/api-client
 
 per-file-ignores =
+    # WPS201: Ignore many methods in the main file
+    # WPS213: Ignore many expressions in the main file
+    # WPS214: Ignore many methods in the main file
+    main.py: WPS201, WPS213, WPS214,
     # S101: Ignore banned assert in testing
     # WPS202: Ignore many members in test suites
     # WPS204: Ignore repeated calls in test suites

--- a/camera/rpi-files/setup.cfg
+++ b/camera/rpi-files/setup.cfg
@@ -14,24 +14,24 @@ max-complexity = 18
 ignore = EXE002, WPS323, WPS453
 
 exclude =
-    # Ignore all generated code
-    api-client,
-    camera/rpi-files/api-client
+  # Ignore all generated code
+  api-client,
+  camera/rpi-files/api-client
 
 per-file-ignores =
-    # WPS201: Ignore many methods in the main file
-    # WPS213: Ignore many expressions in the main file
-    # WPS214: Ignore many methods in the main file
-    main.py: WPS201, WPS213, WPS214
-    # S101: Ignore banned assert in testing
-    # WPS202: Ignore many members in test suites
-    # WPS204: Ignore repeated calls in test suites
-    # WPS437: Ignore protected attribute access
-    # WPS442: Ignore overshadowing pytest fixtures
-    test_*.py: S101, WPS202, WPS204, WPS437, WPS442
+  # WPS201: Ignore many methods in the main file
+  # WPS213: Ignore many expressions in the main file
+  # WPS214: Ignore many methods in the main file
+  main.py: WPS201, WPS213, WPS214
+  # S101: Ignore banned assert in testing
+  # WPS202: Ignore many members in test suites
+  # WPS204: Ignore repeated calls in test suites
+  # WPS437: Ignore protected attribute access
+  # WPS442: Ignore overshadowing pytest fixtures
+  test_*.py: S101, WPS202, WPS204, WPS437, WPS442
 
 
 [tool:pytest]
 norecursedirs =
-    # Ignore all generated code
-    api-client
+  # Ignore all generated code
+  api-client

--- a/camera/rpi-files/setup.cfg
+++ b/camera/rpi-files/setup.cfg
@@ -15,8 +15,7 @@ ignore = EXE002, WPS323, WPS453
 
 exclude =
   # Ignore all generated code
-  api-client,
-  camera/rpi-files/api-client
+  api-client
 
 per-file-ignores =
   # WPS201: Ignore many methods in the main file

--- a/camera/rpi-files/uploader.py
+++ b/camera/rpi-files/uploader.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+"""Data upload module.
+
+Uploads data to API endpoint.
+"""
+
+from datetime import datetime
+
+from data_batcher import Batch
+from events import EventType, create_event
+from openapi_client import ApiClient, CameraEvent, CamerasApi, Configuration
+from openapi_client.rest import ApiException
+
+
+class Uploader(object):
+    """Uploads events to API endpoint."""
+
+    def __init__(self, device_id: int, configuration: Configuration):
+        """Save path for writing.
+
+        Args:
+            device_id: device ID for writing
+            configuration: API client configuration
+        """
+        self._device_id = device_id
+        self._api_client = ApiClient(configuration)
+        self._api = CamerasApi(self._api_client)
+
+    def start(self, timestamp):
+        """Notify endpoint that upload starts.
+
+        Args:
+            timestamp: start time
+        """
+        event = create_event(EventType.monitoring_started, timestamp)
+        self._send_single_event(event)
+
+    def send(self, batch: Batch) -> bool:
+        """Send batch of events to the server.
+
+        Args:
+            batch: batch of events
+
+        Returns:
+            true when all uploads finalized
+        """
+        return self._send_all_as(
+            batch.entering, EventType.person_entered,
+        ) and self._send_all_as(batch.leaving, EventType.person_left)
+
+    def end(self, timestamp):
+        """Notify endpoint that upload ends.
+
+        Args:
+            timestamp: end time
+        """
+        event = create_event(EventType.monitoring_ended, timestamp)
+        self._send_single_event(event)
+        self._api_client.close()
+
+    def _send_single_event(self, event: CameraEvent) -> bool:
+        """Send single CameraEvent to endpoint.
+
+        Args:
+            event: CameraEvent to send
+
+        Raises:
+            RuntimeError: on upload failure
+
+        Returns:
+            HTTP response object
+        """
+        camera_pk = str(self._device_id)
+        try:
+            self._api.cameras_events_create(camera_pk, event)
+        except ApiException as ex:
+            msg = 'Could not upload event: {0}'.format(ex)
+            raise RuntimeError(msg)
+
+        return True
+
+    def _send_all_as(self, events, event_type: EventType) -> bool:
+        """Send all events as given type.
+
+        Args:
+            events: list of timestamps
+            event_type: type of events to send
+
+        Returns:
+            true when all uploads finalized
+        """
+        for timestamp in events:
+            datetimestamp = datetime.fromtimestamp(timestamp).astimezone()
+            event = create_event(event_type, datetimestamp)
+            if not self._send_single_event(event):
+                return False
+
+        return True

--- a/camera/rpi-files/uploader.py
+++ b/camera/rpi-files/uploader.py
@@ -16,23 +16,19 @@ from openapi_client.rest import ApiException
 class Uploader(object):
     """Uploads events to API endpoint."""
 
-    def __init__(self, device_id: int, configuration: Configuration):
+    def __init__(self, device_id: int, configuration: Configuration, timestamp:datetime):
         """Save path for writing.
 
         Args:
             device_id: device ID for writing
             configuration: API client configuration
+            timestamp: start time
         """
         self._device_id = device_id
         self._api_client = ApiClient(configuration)
         self._api = CamerasApi(self._api_client)
 
-    def start(self, timestamp):
-        """Notify endpoint that upload starts.
-
-        Args:
-            timestamp: start time
-        """
+        # Send start event
         event = create_event(EventType.monitoring_started, timestamp)
         self._send_single_event(event)
 

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1,206 +1,407 @@
-openapi: "3.0.0"
+swagger: '2.0'
 info:
-  version: 0.0.0
   title: EatersLab API
-servers:
-  - url: https://eaterslab.example/beta
+  version: v1
+host: eaterslab.herokuapp.com
+schemes:
+  - https
+basePath: /api/beta
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  Basic:
+    type: basic
+security:
+  - Basic: []
 paths:
-  /cameras/{id}/events:
-    post:
-      summary: Capture single camera event from authenticated camera
-      security:
-        - deviceId: []
-          apikey: []
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: integer
-            minimum: 1
-          description: Camera ID
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CameraEvent"
-      responses:
-        201:
-          description: Event saved.
-        401:
-          $ref: '#/components/responses/KeyUnauthorizedError'
-        500:
-          description: Internal server error. Event not saved.
-  /cameras/{id}/events/batch:
-    post:
-      summary: Log batch of camera events from authenticated camera
-      security:
-        - deviceId: []
-          apikey: []
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: integer
-            minimum: 1
-          description: Camera ID
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CameraEventArray"
-      responses:
-        201:
-          description: All log entries were created
-        401:
-          $ref: '#/components/responses/KeyUnauthorizedError'
-        500:
-          description: Internal server error. No events saved.
-  /cafeterias:
+  /cafeterias/:
     get:
-      summary: List all cafeterias
+      operationId: cafeterias_list
+      description: ''
+      parameters: []
       responses:
-        200:
-          description: Array of cafeterias
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CafeteriaPublicArray"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    post:
-      summary: Create new cafeteria
-      requestBody:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Cafeteria'
+      tags:
+        - cafeterias
+    parameters: []
+  /cafeterias/{cafeteria_pk}/fixed_menu_options/:
+    get:
+      operationId: cafeterias_fixed_menu_options_list
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/FixedMenuOption'
+      tags:
+        - cafeterias
+    parameters:
+      - name: cafeteria_pk
+        in: path
         required: true
-        content:
-          application/json:
-            schema:
-              allOf:
-                - $ref: "#/components/schemas/CafeteriaPublicProperties"
-                - $ref: "#/components/schemas/CafeteriaPrivateProperties"
+        type: string
+  /cafeterias/{cafeteria_pk}/fixed_menu_options/{id}/:
+    get:
+      operationId: cafeterias_fixed_menu_options_read
+      description: ''
+      parameters: []
       responses:
-        201:
-          description: New cafeteria ID
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ObjectId"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-components:
-  securitySchemes:
-    deviceId:
-      type: apiKey
-      in: header
-      name: X-DEVICE-ID
-    apiKey:
-      type: apiKey
-      in: header
-      name: X-API-KEY
-  schemas:
-    ObjectId:
-      required:
-        - id
-      properties:
-        id:
-          type: integer
-          format: int32
-          minimum: 1
-    Timestamp:
-      description: Timestamp with RFC 3339 datetime.
-      required:
-        - timestamp
-      properties:
-        timestamp:
-          type: string
-          format: date-time
-      example:
-        timestamp: "2017-07-21T17:32:28Z"
-    CameraEventType:
-      required:
-        - event_type
-      properties:
-        event_type:
-          type: string
-          enum:
-            - monitoring_started
-            - monitoring_ended
-            - person_entered
-            - person_left
-      example:
-        event_type: "person_entered"
-    CameraEvent:
-      allOf:
-          - $ref: "#/components/schemas/CameraEventType"
-          - $ref: "#/components/schemas/Timestamp"
-    CameraEventArray:
-      type: array
-      items:
-        $ref: "#/components/schemas/CameraEvent"
-      example:
-        - event_type: "monitoring_started"
-          timestamp: "2017-07-21T17:32:28Z"
-        - event_type: "person_entered"
-          timestamp: "2017-07-21T17:32:56Z"
-        - event_type: "person_entered"
-          timestamp: "2017-07-21T17:33:10Z"
-        - event_type: "person_left"
-          timestamp: "2017-07-21T17:33:40Z"
-    CafeteriaPublicProperties:
-      required:
-        - name
-      properties:
-        name:
-          type: string
-    CafeteriaPrivateProperties:
-      required:
-        - capacity
-      properties:
-        capacity:
-          type: integer
-          format: int32
-          minimum: 1
-    CafeteriaPublic:
-      allOf:
-        - $ref: "#/components/schemas/ObjectId"
-        - $ref: "#/components/schemas/CafeteriaPublicProperties"
-      example:
-        id: 1
-        name: "Kubuś"
-    CafeteriaPrivate:
-      allOf:
-        - $ref: "#/components/schemas/ObjectId"
-        - $ref: "#/components/schemas/CafeteriaPublicProperties"
-        - $ref: "#/components/schemas/CafeteriaPrivateProperties"
-      example:
-        id: 1
-        name: "Kubuś"
-        capacity: 50
-    CafeteriaPublicArray:
-      type: array
-      items:
-        $ref: "#/components/schemas/CafeteriaPublic"
-    Error:
-      required:
-        - code
-        - message
-      properties:
-        code:
-          type: integer
-          format: int32
-        message:
-          type: string
-  responses:
-    KeyUnauthorizedError:
-      description: API key is missing or invalid
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FixedMenuOption'
+      tags:
+        - cafeterias
+    parameters:
+      - name: cafeteria_pk
+        in: path
+        required: true
+        type: string
+      - name: id
+        in: path
+        required: true
+        type: string
+  /cafeterias/{cafeteria_pk}/fixed_menu_options/{option_pk}/reviews/:
+    get:
+      operationId: cafeterias_fixed_menu_options_reviews_list
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/FixedMenuOptionReview'
+      tags:
+        - cafeterias
+    parameters:
+      - name: cafeteria_pk
+        in: path
+        required: true
+        type: string
+      - name: option_pk
+        in: path
+        required: true
+        type: string
+  /cafeterias/{cafeteria_pk}/fixed_menu_options/{option_pk}/reviews/{id}/:
+    get:
+      operationId: cafeterias_fixed_menu_options_reviews_read
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FixedMenuOptionReview'
+      tags:
+        - cafeterias
+    parameters:
+      - name: cafeteria_pk
+        in: path
+        required: true
+        type: string
+      - name: id
+        in: path
+        required: true
+        type: string
+      - name: option_pk
+        in: path
+        required: true
+        type: string
+  /cafeterias/{id}/:
+    get:
+      operationId: cafeterias_read
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/Cafeteria'
+      tags:
+        - cafeterias
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this cafeteria.
+        required: true
+        type: integer
+  /cameras/{camera_pk}/events/:
+    post:
+      operationId: cameras_events_create
+      description: ''
+      parameters:
+        - name: data
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/CameraEvent'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/CameraEvent'
+      tags:
+        - cameras
+    parameters:
+      - name: camera_pk
+        in: path
+        required: true
+        type: string
+  /fixed_menu_reviews/:
+    post:
+      operationId: fixed_menu_reviews_create
+      description: ''
+      parameters:
+        - name: data
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/FixedMenuOptionReview'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/FixedMenuOptionReview'
+      tags:
+        - fixed_menu_reviews
+    parameters: []
+  /menu_option_tags/:
+    get:
+      operationId: menu_option_tags_list
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/MenuOptionTag'
+      tags:
+        - menu_option_tags
+    post:
+      operationId: menu_option_tags_create
+      description: ''
+      parameters:
+        - name: data
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/MenuOptionTag'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/MenuOptionTag'
+      tags:
+        - menu_option_tags
+    parameters: []
+  /menu_option_tags/{id}/:
+    get:
+      operationId: menu_option_tags_read
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/MenuOptionTag'
+      tags:
+        - menu_option_tags
+    parameters:
+      - name: id
+        in: path
+        description: A unique integer value identifying this menu option tag.
+        required: true
+        type: integer
+  /upload/artifacts/beta/{filename}/:
+    put:
+      operationId: upload_artifacts_beta_update
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      consumes: []
+      tags:
+        - upload
+    parameters:
+      - name: filename
+        in: path
+        required: true
+        type: string
+  /upload/artifacts/{filename}/:
+    put:
+      operationId: upload_artifacts_update
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      consumes: []
+      tags:
+        - upload
+    parameters:
+      - name: filename
+        in: path
+        required: true
+        type: string
+definitions:
+  Cafeteria:
+    required:
+      - name
+      - description
+      - sub_description
+      - longitude
+      - latitude
+      - logo_url
+      - address
+      - opened_from
+      - opened_to
+    type: object
+    properties:
+      id:
+        title: ID
+        type: integer
+        readOnly: true
+      name:
+        title: Name
+        type: string
+        maxLength: 128
+        minLength: 1
+      description:
+        title: Description
+        type: string
+        maxLength: 256
+        minLength: 1
+      sub_description:
+        title: Sub description
+        type: string
+        maxLength: 512
+        minLength: 1
+      longitude:
+        title: Longitude
+        type: number
+        maximum: 180.0
+        minimum: -180.0
+      latitude:
+        title: Latitude
+        type: number
+        maximum: 90.0
+        minimum: -90.0
+      logo_url:
+        title: Logo url
+        type: string
+        maxLength: 2048
+        minLength: 1
+      address:
+        title: Address
+        type: string
+        maxLength: 256
+        minLength: 1
+      opened_from:
+        title: Opened from
+        type: string
+      opened_to:
+        title: Opened to
+        type: string
+  FixedMenuOption:
+    required:
+      - name
+      - price
+      - photo_url
+    type: object
+    properties:
+      id:
+        title: ID
+        type: integer
+        readOnly: true
+      name:
+        title: Name
+        type: string
+        maxLength: 128
+        minLength: 1
+      price:
+        title: Price
+        type: number
+        minimum: 0.0
+      photo_url:
+        title: Photo url
+        type: string
+        maxLength: 2048
+        minLength: 1
+      avg_review_stars:
+        title: Avg review stars
+        type: number
+        readOnly: true
+  FixedMenuOptionReview:
+    required:
+      - stars
+      - author_nick
+      - review_time
+      - option
+    type: object
+    properties:
+      id:
+        title: ID
+        type: integer
+        readOnly: true
+      stars:
+        title: Stars
+        type: integer
+        maximum: 5
+        minimum: 0
+      author_nick:
+        title: Author nick
+        type: string
+        maxLength: 64
+        minLength: 1
+      review_time:
+        title: Review time
+        type: string
+        format: date-time
+      option:
+        title: Option
+        type: integer
+  CameraEvent:
+    required:
+      - event_type
+      - timestamp
+    type: object
+    properties:
+      event_type:
+        title: Event type
+        type: integer
+        enum:
+          - 0
+          - 1
+          - 2
+          - 3
+      timestamp:
+        title: Timestamp
+        type: string
+        format: date-time
+  MenuOptionTag:
+    type: object
+    properties:
+      id:
+        title: ID
+        type: integer
+        readOnly: true
+      name:
+        title: Name
+        type: string
+        readOnly: true
+        minLength: 1


### PR DESCRIPTION
* Update old API definition with generated code
* Upload start/end events
* Upload enter/leave events in separate requests

Timestamps are currently either `datetime`s or `float`s. I will clean it up in a follow-up PR.
Closes #112.