### PR TITLE
Add camera auth via token

### DIFF
--- a/django-server/server/admin/admin.py
+++ b/django-server/server/admin/admin.py
@@ -4,6 +4,8 @@ from django.contrib.admin import AdminSite
 from django.contrib.admin import ModelAdmin
 from django.db.models import Subquery, OuterRef, Max
 from django.utils.html import format_html
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
 
 from .views import StatsView
 
@@ -60,3 +62,6 @@ admin_site.register(Camera, CameraAdmin)
 admin_site.register(FixedMenuOption)
 admin_site.register(FixedMenuOptionReview)
 admin_site.register(MenuOptionTag)
+
+UserAdmin.list_display = ['email', 'first_name', 'last_name', 'is_active', 'date_joined', 'is_staff']
+admin_site.register(User)

--- a/django-server/server/api/models.py
+++ b/django-server/server/api/models.py
@@ -6,6 +6,22 @@ from django.db.models import F
 
 from datetime import timedelta
 
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    """
+    When new user is created he gets token generated
+    in order to be able to send camera events to his
+    canteens
+    """
+    if created:
+        Token.objects.create(user=instance)
+
 
 class Cafeteria(models.Model):
     name = models.CharField(max_length=128)

--- a/django-server/server/api/urls.py
+++ b/django-server/server/api/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path
+from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework_nested.routers import DefaultRouter, NestedSimpleRouter
 
 from .views import *
@@ -30,6 +31,7 @@ urlpatterns = [
     path('', include(cameras_router.urls)),
     path('upload/artifacts/<str:filename>/', UploadArtifactsView.as_view()),
     path('upload/artifacts/beta/<str:filename>/', UploadArtifactsBetaView.as_view()),
+    path('token-auth/', obtain_auth_token),
 ]
 urlpatterns.extend([
     path('cafeterias/<int:cafeteria_pk>/stats/{}'.format(name), view.as_view())


### PR DESCRIPTION
Now when the user is created he also receives his token. If only the login credentials are known the token can be received via posting to 
`curl -X POST "http://127.0.0.1:8000/api/beta/token-auth/" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{  \"username\": \"admin\",  \"password\": \"password\"}"`
which as for me worked for the newly created user (was looking for solution for old admin but didn't find it - for now we can see the token by using admin site and starting the deletion of user from admin panel because then all the fields related to the user are displayed which includes token)
Then when the camera client send POST to server with events data it has to add extra header field in request in order to get authentificated for its cafeteria owner
`curl -X POST "http://127.0.0.1:8000/api/beta/cameras/1/events/" -H  "accept: application/json" -H  "Content-Type: application/json" -H  "Authorization: Token token_value" -d "{  \"event_type\": 4,  \"timestamp\": \"2020-05-29T21:04:20.193Z\",  \"event_value\": 0}"`
where token_value is a value received during authetification process